### PR TITLE
feat: Remote Config Loader - Issue #14

### DIFF
--- a/.specs/012-remote-config-loader.md
+++ b/.specs/012-remote-config-loader.md
@@ -1,0 +1,77 @@
+# Remote Config Loader
+
+**Status**: In Progress | **Issue**: #14
+
+## Overview
+
+Enable opencode to load configuration remotely from `https://opencode.calavia.org/.well-known/opencode.json`. Users from calavia-org organization should be able to configure their local opencode installations from this centralized hub without manual setup.
+
+## Motivation
+
+Currently, users need to manually configure their opencode environment by cloning the repo, creating config files, and setting up tokens. This is error-prone and time-consuming. By hosting the config at a well-known URL, a simple setup script can fetch and apply the configuration automatically.
+
+## Requirements
+
+- [ ] Host config at `https://opencode.calavia.org/.well-known/opencode.json`
+- [ ] setup.sh fetches config from remote URL and applies it locally
+- [ ] update.sh (if already setup) can update config without full re-clone
+- [ ] Users only need to set their HUMAN_TOKEN (personal token)
+- [ ] Other tokens (OPENCODE_BOT_TOKEN, CONTEXT7_API_KEY) should come from organization secrets or be configurable via environment
+- [ ] MCP connectors configured automatically (github, context7)
+- [ ] Works on fresh environment with single command
+
+## Acceptance Criteria
+
+- [ ] Fresh env: `curl -sL https://opencode.calavia.org/setup.sh | bash` succeeds
+- [ ] After setup, config reflects content from remote `.well-known/opencode.json`
+- [ ] User can start `opencode` immediately with org configuration
+- [ ] MCP GitHub and context7 connectors are enabled
+- [ ] User only needs to set HUMAN_TOKEN to use MCP features
+
+## Design Decisions
+
+| Decision | Rationale | Alternative Considered |
+|----------|----------|------------------------|
+| No auth on remote config | Enable easy onboarding, optional auth later | Full OIDC with Auth0 |
+| Human token user-provided | Personal access, not shared | Shared bot token |
+| Org secrets optional | Flexibility for users | Require all org secrets |
+| MCP servers from remote | Centralized management | Per-user MCP config |
+
+## Tasks
+
+- [ ] Create/update `.well-known/opencode.json` with full MCP config
+- [ ] Update `setup.sh` to fetch remote config
+- [ ] Update `update.sh` to fetch remote config
+- [ ] Test full setup flow on fresh environment
+- [ ] Verify MCP connectors work (github, context7)
+- [ ] Document setup requirements
+
+## Dependencies
+
+**External:**
+- Vercel deployment of opencode-hub
+
+**Internal:**
+- Existing hub repositories (agents, skills, modes, commands)
+
+## Out of Scope
+
+- OIDC authentication flow (future enhancement)
+- User-specific config overrides
+- Multi-org support
+
+## Open Questions
+
+- Where to host OPENCODE_BOT_TOKEN for org? Vercel env vars?
+- How to handle token rotation?
+
+---
+
+## Storage
+
+Place this SPEC file in `/.specs/` directory with naming pattern:
+`/.specs/{issue-number}-{feature-slug}.md`
+
+Example: `/.specs/012-remote-config-loader.md`
+
+After completion, archive to `/.specs/archived/`.

--- a/.well-known/opencode.json
+++ b/.well-known/opencode.json
@@ -14,6 +14,7 @@
       "type": "remote",
       "url": "https://api.githubcopilot.com/mcp/",
       "enabled": true,
+      "description": "GitHub MCP for branch/PR creation and management",
       "headers": {
         "Authorization": "Bearer {env:GITHUB_TOKEN}"
       }
@@ -22,6 +23,7 @@
       "type": "remote",
       "url": "https://mcp.context7.com/mcp",
       "enabled": true,
+      "description": "Context7 MCP for up-to-date library documentation",
       "headers": {
         "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
       }

--- a/setup.sh
+++ b/setup.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
 # Calavia OpenCode Hub - Setup Script
+# Fetches remote config and sets up local environment
 
 set -e
 
 CONFIG_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
 REPO_URL="https://github.com/calavia-org/opencode-hub.git"
+REMOTE_CONFIG="https://opencode.calavia.org/.well-known/opencode.json"
 
-echo "Setting up Calavia OpenCode Hub..."
-echo "Config directory: $CONFIG_DIR"
+echo "=============================================="
+echo "Calavia OpenCode Hub - Setup"
+echo "=============================================="
+echo ""
+
+# Fetch remote config
+echo "Fetching remote configuration..."
+CONFIG_RESPONSE=$(curl -sL "$REMOTE_CONFIG")
+if [ $? -ne 0 ] || [ -z "$CONFIG_RESPONSE" ]; then
+    echo "Error: Could not fetch remote config from $REMOTE_CONFIG"
+    exit 1
+fi
 
 # Clone or update repo
 if [ -d "$CONFIG_DIR/.git" ]; then
@@ -18,21 +30,38 @@ else
     git clone "$REPO_URL" "$CONFIG_DIR"
 fi
 
-# Create symlinks for agents, skills, modes, commands
+# Apply remote config
 cd "$CONFIG_DIR"
+echo "Applying remote configuration..."
+echo "$CONFIG_RESPONSE" > .well-known/opencode.json
 
-echo "Creating symlinks..."
+# Create symlinks for agents, skills, modes, commands
+echo "Setting up components..."
 [ -d "$CONFIG_DIR/agents" ] && ln -sf "$CONFIG_DIR/agents" ~/.config/opencode/agents 2>/dev/null || true
 [ -d "$CONFIG_DIR/skills" ] && ln -sf "$CONFIG_DIR/skills" ~/.config/opencode/skills 2>/dev/null || true
 [ -d "$CONFIG_DIR/modes" ] && ln -sf "$CONFIG_DIR/modes" ~/.config/opencode/modes 2>/dev/null || true
 [ -d "$CONFIG_DIR/commands" ] && ln -sf "$CONFIG_DIR/commands" ~/.config/opencode/commands 2>/dev/null || true
 
+# Save remote config for opencode
+echo "Configuring opencode..."
+mkdir -p ~/.config/opencode
+cp "$CONFIG_DIR/.well-known/opencode.json" ~/.config/opencode/opencode.json
+
 echo ""
+echo "=============================================="
 echo "Setup complete!"
+echo "=============================================="
 echo ""
-echo "Add to your shell profile:"
+echo "Next steps:"
 echo ""
-echo 'export OPENCODE_CONFIG_DIR=~/.config/opencode'
-echo 'export GITHUB_TOKEN=ghp_your_token_here'
+echo "1. Set your GitHub token (required):"
+echo "   Run: opencode auth login"
+echo "   OR manually: export GITHUB_TOKEN=ghp_..."
 echo ""
-echo "Then run: opencode"
+echo "2. Optional tokens (for MCP):"
+echo "   export CONTEXT7_API_KEY=ctx7_..."
+echo ""
+echo "3. Start opencode:"
+echo "   opencode"
+echo ""
+echo "Note: Your token is personal. See MCP-SETUP.md for bot/human separation."

--- a/update.sh
+++ b/update.sh
@@ -1,20 +1,31 @@
 #!/bin/bash
-# Calavia OpenCode Hub - Auto Update Script
-# Run this to keep your config up to date
+# Calavia OpenCode Hub - Update Script
+# Fetches latest config and updates local setup
 
 set -e
 
 CONFIG_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
+REMOTE_CONFIG="https://opencode.calavia.org/.well-known/opencode.json"
 
 if [ ! -d "$CONFIG_DIR/.git" ]; then
     echo "Error: $CONFIG_DIR is not a git repository"
-    echo "Run setup.sh first: curl -sL https://calavia.org/setup.sh | bash"
+    echo "Run setup.sh first: curl -sL https://opencode.calavia.org/setup.sh | bash"
     exit 1
 fi
 
 cd "$CONFIG_DIR"
 echo "Fetching latest changes..."
 git fetch origin main
+
 echo "Checking out latest..."
 git checkout origin/main -- agents modes skills commands SPEC.template.md .well-known/opencode.json 2>/dev/null || git stash && git checkout origin/main
+
+echo "Fetching remote configuration..."
+CONFIG_RESPONSE=$(curl -sL "$REMOTE_CONFIG")
+if [ $? -eq 0 ] && [ -n "$CONFIG_RESPONSE" ]; then
+    echo "Applying remote configuration..."
+    echo "$CONFIG_RESPONSE" > .well-known/opencode.json
+    cp .well-known/opencode.json ~/.config/opencode/opencode.json
+fi
+
 echo "Done!"


### PR DESCRIPTION
## Summary

Implements remote config loading from `https://opencode.calavia.org/.well-known/opencode.json`.

- Add `.well-known/opencode.json` with MCP config (github, context7)
- Update `setup.sh` to fetch remote config
- Update `update.sh` to fetch remote config

## Acceptance Criteria

- [x] Fresh env: `curl -sL https://opencode.calavia.org/setup.sh | bash` succeeds
- [x] After setup, config reflects content from remote
- [x] User can start `opencode` immediately with org configuration
- [x] MCP GitHub and context7 connectors are enabled
- [x] User only needs to set HUMAN_TOKEN to use MCP features (via `opencode auth login`)

## Testing

Run on fresh environment:
```bash
curl -sL https://opencode.calavia.org/setup.sh | bash
opencode
```