### PR TITLE
feat: add index.json files for remote loading - Issue #14

### DIFF
--- a/.specs/012-remote-config-loader.md
+++ b/.specs/012-remote-config-loader.md
@@ -1,0 +1,86 @@
+# Remote Config Loader
+
+## Overview
+
+Enable opencode to load configuration remotely from `https://opencode.calavia.org/.well-known/opencode.json` using OAuth flow.
+
+## Motivation
+
+Centralized configuration that users can fetch via OAuth. No local clones needed - all loaded from remote.
+
+## Testing Protocol
+
+### Test 1: Remote Config Availability
+```bash
+curl -sI https://opencode.calavia.org/.well-known/opencode.json
+# Expected: 200 OK
+```
+
+### Test 2: Remote Components Availability
+```bash
+curl -sI https://opencode.calavia.org/agents/go-deployer.md
+curl -sI https://opencode.calavia.org/skills/spec-driven/SKILL.md
+# Expected: 200 OK
+```
+
+### Test 3: OAuth Config Loading
+```bash
+# In a fresh directory
+opencode auth login  # Authenticate with GitHub
+# After auth, OpenCode should fetch .well-known/opencode from issuer
+```
+
+## Requirements
+
+- [ ] Test remote config accessible: `https://opencode.calavia.org/.well-known/opencode.json` → 200
+- [ ] Test OAuth flow loads remote config
+- [ ] Test MCP connectors work (github, context7)
+- [ ] Test agents load from remote URLs
+- [ ] Test skills load from remote URLs
+
+## Debug Steps
+
+1. Check remote config: `curl https://opencode.calavia.org/.well-known/opencode.json`
+2. Watch OpenCode logs during `opencode auth login`
+3. Verify components accessible individually
+
+## Known Issues
+
+- `https://opencode.calavia.org/agents/` returns 404 (directory index)
+- Individual `.md` files accessible but directory scan may fail
+- Need to verify OAuth flow actually fetches remote
+
+## Test Results (to be filled)
+
+### Test 1: Remote Config
+```bash
+curl -sI https://opencode.calavia.org/.well-known/opencode.json
+# Result: 200 OK ✓
+```
+
+### Test 2: Remote Components
+```bash
+curl -sI https://opencode.calavia.org/agents/go-deployer.md
+# Result: 200 OK ✓
+
+curl -sI https://opencode.calavia.org/skills/spec-driven/SKILL.md  
+# Result: 200 OK ✓
+
+curl -sI https://opencode.calavia.org/agents/
+# Result: 404 (needs fix)
+```
+
+## Tasks
+
+- [ ] Test OAuth remote loading
+- [ ] Document what works / what doesn't
+- [ ] Fix issues found
+- [ ] Update SPEC with final implementation
+
+---
+
+## Storage
+
+`/.specs/012-remote-config-loader.md`
+
+After completion, archive to `/.specs/archived/`.

--- a/agents/index.json
+++ b/agents/index.json
@@ -1,0 +1,21 @@
+{
+  "agents": [
+    { "name": "spec-driven", "description": "SPEC-driven development orchestrator" },
+    { "name": "go-implementer", "description": "Implements Go code" },
+    { "name": "go-tester", "description": "Runs Go tests" },
+    { "name": "go-verifier", "description": "Validates non-functional" },
+    { "name": "go-deployer", "description": "Deploys to Docker/K8s" },
+    { "name": "java-implementer", "description": "Implements Java code" },
+    { "name": "java-tester", "description": "Runs JUnit tests" },
+    { "name": "java-verifier", "description": "Validates non-functional" },
+    { "name": "java-deployer", "description": "Deploys to Docker/K8s" },
+    { "name": "python-implementer", "description": "Implements Python code" },
+    { "name": "python-tester", "description": "Runs pytest tests" },
+    { "name": "python-verifier", "description": "Validates non-functional" },
+    { "name": "python-deployer", "description": "Deploys to Docker/K8s" },
+    { "name": "terraform-implementer", "description": "Writes Terraform infrastructure code" },
+    { "name": "terraform-tester", "description": "Tests and security scans" },
+    { "name": "terraform-verifier", "description": "TFLint, checkov, OPA validation" },
+    { "name": "terraform-deployer", "description": "Deploys to Terraform Cloud" }
+  ]
+}

--- a/commands/index.json
+++ b/commands/index.json
@@ -1,0 +1,5 @@
+{
+  "commands": [
+    { "name": "spec", "description": "Create and manage specifications" }
+  ]
+}

--- a/modes/index.json
+++ b/modes/index.json
@@ -1,0 +1,5 @@
+{
+  "modes": [
+    { "name": "spec-driven", "description": "SPEC-driven development workflow" }
+  ]
+}

--- a/skills/index.json
+++ b/skills/index.json
@@ -1,0 +1,29 @@
+{
+  "skills": [
+    {
+      "name": "spec-driven",
+      "description": "Create and manage specifications for features",
+      "files": ["SKILL.md"]
+    },
+    {
+      "name": "github-workflow",
+      "description": "GitHub issue/branch/PR automation",
+      "files": ["SKILL.md"]
+    },
+    {
+      "name": "context7",
+      "description": "Up-to-date library documentation",
+      "files": ["SKILL.md"]
+    },
+    {
+      "name": "root-cause-analysis",
+      "description": "Debug distributed systems",
+      "files": ["SKILL.md"]
+    },
+    {
+      "name": "repo-bootstrap",
+      "description": "Project setup",
+      "files": ["SKILL.md"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add `index.json` files to enable OpenCode remote loading of agents, skills, modes, and commands.

- `agents/index.json` - List of 17 agents
- `skills/index.json` - List of 5 skills
- `modes/index.json` - List of 1 mode
- `commands/index.json` - List of 1 command
- `.specs/012-remote-config-loader.md` - SPEC for remote config loading

Without these index files, OpenCode can't discover remote components (directory returns 404).

## Test Commands

```bash
# After deployment
curl -sI https://opencode.calavia.org/agents/index.json  # Should be 200
curl -sI https://opencode.calavia.org/skills/index.json  # Should be 200
```