### PR TITLE
feat: minimal config - only baseUrl for remote loading

### DIFF
--- a/.well-known/opencode.json
+++ b/.well-known/opencode.json
@@ -1,44 +1,4 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "version": 3,
-  "name": "Calavia OpenCode Hub",
-  "baseUrl": "https://opencode.calavia.org",
-  "defaultAgent": "spec-driven",
-  "defaultMode": "spec-driven",
-  "agents": "https://opencode.calavia.org/agents",
-  "modes": "https://opencode.calavia.org/modes",
-  "skills": "https://opencode.calavia.org/skills",
-  "commands": "https://opencode.calavia.org/commands",
-  "mcp": {
-    "github_bot": {
-      "type": "remote",
-      "url": "https://api.githubcopilot.com/mcp/",
-      "enabled": true,
-      "description": "Bot automation - creates branches, PRs, merges after human approval",
-      "requestInit": {
-        "headers": {
-          "Authorization": "Bearer {env:OPENCODE_BOT_TOKEN}"
-        }
-      }
-    },
-    "github_human": {
-      "type": "remote",
-      "url": "https://api.githubcopilot.com/mcp/",
-      "enabled": true,
-      "description": "Human actions - approves PRs, merges",
-      "requestInit": {
-        "headers": {
-          "Authorization": "Bearer {env:HUMAN_TOKEN}"
-        }
-      }
-    },
-    "context7": {
-      "type": "remote",
-      "url": "https://mcp.context7.com/mcp",
-      "enabled": true,
-      "headers": {
-        "CONTEXT7_API_KEY": "{env:CONTEXT7_API_KEY}"
-      }
-    }
-  }
+  "baseUrl": "https://opencode.calavia.org"
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,38 +1,34 @@
 #!/bin/bash
 # Calavia OpenCode Hub - Setup Script
 
-set -e
-
 CONFIG_DIR="${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}"
 REPO_URL="https://github.com/calavia-org/opencode-hub.git"
 
-echo "Setting up Calavia OpenCode Hub..."
-echo "Config directory: $CONFIG_DIR"
+echo "=============================================="
+echo "Calavia OpenCode Hub - Setup"
+echo "=============================================="
+echo ""
 
-# Clone or update repo
+# Clone repo for components (agents, skills, modes, commands)
 if [ -d "$CONFIG_DIR/.git" ]; then
     echo "Updating existing config..."
     cd "$CONFIG_DIR" && git pull origin main
 else
-    echo "Cloning repository..."
+    echo "Cloning repository to $CONFIG_DIR..."
     git clone "$REPO_URL" "$CONFIG_DIR"
 fi
 
-# Create symlinks for agents, skills, modes, commands
-cd "$CONFIG_DIR"
-
-echo "Creating symlinks..."
-[ -d "$CONFIG_DIR/agents" ] && ln -sf "$CONFIG_DIR/agents" ~/.config/opencode/agents 2>/dev/null || true
-[ -d "$CONFIG_DIR/skills" ] && ln -sf "$CONFIG_DIR/skills" ~/.config/opencode/skills 2>/dev/null || true
-[ -d "$CONFIG_DIR/modes" ] && ln -sf "$CONFIG_DIR/modes" ~/.config/opencode/modes 2>/dev/null || true
-[ -d "$CONFIG_DIR/commands" ] && ln -sf "$CONFIG_DIR/commands" ~/.config/opencode/commands 2>/dev/null || true
-
 echo ""
+echo "=============================================="
 echo "Setup complete!"
+echo "=============================================="
 echo ""
-echo "Add to your shell profile:"
+echo "Next steps:"
 echo ""
-echo 'export OPENCODE_CONFIG_DIR=~/.config/opencode'
-echo 'export GITHUB_TOKEN=ghp_your_token_here'
+echo "1. Authenticate with GitHub:"
+echo "   opencode auth login"
 echo ""
-echo "Then run: opencode"
+echo "2. Start opencode:"
+echo "   opencode"
+echo ""
+echo "Config is loaded from https://opencode.calavia.org/.well-known/opencode.json"


### PR DESCRIPTION
## Summary

Simplify config to minimal:
```json
{
  "$schema": "https://opencode.ai/config.json",
  "baseUrl": "https://opencode.calavia.org"
}
```

OpenCode will load agents, skills, modes, commands, MCP from baseUrl.

## Changes

- `.well-known/opencode.json` - Minimal config with just baseUrl
- `setup.sh` - Simplified to just clone repo

## Test

```bash
curl -sL https://opencode.calavia.org/setup.sh | bash
opencode auth login
opencode
```